### PR TITLE
refactor(console): isolate kmscon module

### DIFF
--- a/configurations/nixos/itlnuc7cjyh/default.nix
+++ b/configurations/nixos/itlnuc7cjyh/default.nix
@@ -11,6 +11,7 @@ in
     ++ (with self.nixosModules; [
       base
       hardware
+      kmscon
       network
       sshd
       sgx

--- a/configurations/nixos/rmg21/default.nix
+++ b/configurations/nixos/rmg21/default.nix
@@ -15,6 +15,7 @@ in
       fcitx5
       gui
       hardware
+      kmscon
       kde
       network
       nvidia

--- a/modules/nixos/kmscon/default.nix
+++ b/modules/nixos/kmscon/default.nix
@@ -1,0 +1,40 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+
+let
+  kmsconTty = "tty1";
+  locale = config.i18n.defaultLocale or "zh_CN.UTF-8";
+in
+{
+  services.kmscon = {
+    enable = true;
+    hwRender = true;
+    fonts = [
+      {
+        name = "Maple Mono NF CN";
+        package = pkgs.maple-font."NF-CN";
+      }
+    ];
+    extraOptions = [
+      "--xkb-layout=us"
+      "--locale=${locale}"
+    ];
+    extraConfig = "font-size=18";
+  };
+
+  systemd.services."kmsconvt@${kmsconTty}" = {
+    enable = true;
+    wantedBy = [ "getty.target" ];
+  };
+
+  systemd.services."getty@${kmsconTty}".enable = lib.mkForce false;
+
+  console = {
+    packages = [ pkgs.terminus_font ];
+    font = "Lat2-Terminus16";
+  };
+}

--- a/modules/nixos/wsl/default.nix
+++ b/modules/nixos/wsl/default.nix
@@ -1,8 +1,4 @@
-{
-  flake,
-  lib,
-  ...
-}:
+{ flake, lib, ... }:
 let
   inherit (flake.config) user;
 in


### PR DESCRIPTION
## Summary
- move the kmscon console configuration into its own modules/nixos/kmscon/default.nix file so it enables Maple Mono NF CN and tty1 takeover when imported
- wire the shared kmscon module into the itlnuc7cjyh and rmg21 hosts and drop the WSL-specific option guard now that the module is opt-in

## Testing
- nix --extra-experimental-features "nix-command flakes" fmt
- nix --extra-experimental-features "nix-command flakes" flake check -v --keep-going --max-jobs 0 *(fails: ssh access to ssh://git@github.com/Kh05ifr4nD/seinx.git is required; command interrupted after repeated fetch failures to avoid multi-hundred-MiB downloads)*
- nix --extra-experimental-features "nix-command flakes" build .#nixosConfigurations.itlnuc7cjyh.config.system.build.toplevel --max-jobs 0 *(fails: ssh access to ssh://git@github.com/Kh05ifr4nD/seinx.git is required)*

------
https://chatgpt.com/codex/tasks/task_b_68f539766694832cb6b6c618cf296f43